### PR TITLE
update node compatibility in docs per latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Compatibility
 * Ember Changeset and Ember Changeset Validations v4
 * Ember.js v3.28 or above
 * Ember CLI v3.28 or above
-* Node.js v12 or above
+* Node.js v20 or above
 
 
 Installation


### PR DESCRIPTION
I missed updating the docs when dropping support for node < 20 in #75.