### PR TITLE
ensure test coverage with Ember 4.12

### DIFF
--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -23,7 +23,7 @@ module.exports = async function () {
         name: 'ember-lts-4.12',
         npm: {
           devDependencies: {
-            'ember-source': '~5.8.0',
+            'ember-source': '~4.12.0',
           },
         },
       },


### PR DESCRIPTION
Something got wrong when upgrading the project with Ember CLI blueprints. And I missed it when reviewing the changes.